### PR TITLE
User Prefs and rememeber paths in file pickers

### DIFF
--- a/Scripts/ComponentPanelDialogResult.cs
+++ b/Scripts/ComponentPanelDialogResult.cs
@@ -38,25 +38,27 @@ public abstract partial class ComponentPanelDialogResult : Control
             Access = FileDialog.AccessEnum.Filesystem,
             UseNativeDialog = true,
             FileMode = FileDialog.FileModeEnum.OpenFile,
-            Title = title
+            Title = title,
+            CurrentDir = UserPrefs.Instance.LastContentPath,
         };
 
         _callback = callback;
 
         _fd.FileSelected += FileSelected;
         _fd.Canceled += FileCanceled;
-        
+
         GetParent().AddChild(_fd);
         _fd.Visible = true;
 
         return string.Empty;
     }
-    
+
     private void FileSelected(string file)
     {
         _callback(file);
         _fd.FileSelected -= FileSelected;
         _fd.Canceled -= FileCanceled;
+        UserPrefs.Instance.LastContentPath =_fd.CurrentDir;
         _fd = null;
     }
 
@@ -65,12 +67,13 @@ public abstract partial class ComponentPanelDialogResult : Control
         FileSelected(string.Empty);
     }
 
+
     public TextureFactory TextureFactory
     {
-        get; 
+        get;
         set;
     }
-    
+
     public virtual Project CurrentProject { get; set; }
-    
+
 }

--- a/Scripts/UserPrefs.cs
+++ b/Scripts/UserPrefs.cs
@@ -1,0 +1,51 @@
+using System;
+using Godot;
+
+public class UserPrefs
+{
+    // Access settings
+    private string _lastContentPath = "";
+    public string LastContentPath
+    {
+        get {
+            return _lastContentPath;
+        }
+        set
+        {
+            if (value != _lastContentPath)
+            {
+                _lastContentPath = value;
+                config.SetValue( Section_Files, Key_LastContentPath, _lastContentPath);
+                config.Save(SettingsPath);
+            }
+        }
+    }
+
+    // Save the settings to a config file
+    private const string SettingsPath = "user://settings.ini";
+    private const string Key_LastContentPath = "LastContentPath";
+    private const string Section_Files = "Files";
+    private ConfigFile config = new ConfigFile();
+
+
+    // Singleton, created on demand
+    private static readonly Lazy<UserPrefs> instance = new Lazy<UserPrefs>(() => new UserPrefs());
+    public static UserPrefs Instance => instance.Value;
+
+     // Private constructor to prevent instantiation from outside the class.
+    private UserPrefs()
+    {
+        config = new ConfigFile();
+        Error err = config.Load(SettingsPath);
+        if (err != Error.Ok)
+        {
+            // Set defaults
+            _lastContentPath = OS.GetSystemDir(OS.SystemDir.Documents);
+            config.SetValue( Section_Files, Key_LastContentPath, _lastContentPath);
+            config.Save(SettingsPath);
+        } else {
+            // Initialize with values from config
+            _lastContentPath = (string)config.GetValue( Section_Files, Key_LastContentPath );
+        }
+    }
+}

--- a/Scripts/UserPrefs.cs.uid
+++ b/Scripts/UserPrefs.cs.uid
@@ -1,0 +1,1 @@
+uid://bc1hjgi08wflj


### PR DESCRIPTION
This adds a very simple "UserPrefs" object that uses godot settings, can be used to save global preferences for the user.

It uses this to remember the file path from the last time a file picker is opened, so when importing multiple images you don't have to keep navigating back to the same place.