### PR TITLE
Restored Shuffle command

### DIFF
--- a/Scenes/ComponentPanels/printed_panel.tscn
+++ b/Scenes/ComponentPanels/printed_panel.tscn
@@ -1,7 +1,7 @@
 [gd_scene format=3 uid="uid://dgxle1a8aquwd"]
 
 [ext_resource type="Texture2D" uid="uid://dn6uytmhm5r7q" path="res://Textures/UI/folder_open_24dp_FFFFFF_FILL0_wght400_GRAD0_opsz24.svg" id="1_qeff1"]
-[ext_resource type="Script" path="res://Scripts/ComponentPanelResults/PrintedPanelDialogResult.cs" id="1_ykbf8"]
+[ext_resource type="Script" uid="uid://3whugn303phg" path="res://Scripts/ComponentPanelResults/PrintedPanelDialogResult.cs" id="1_ykbf8"]
 [ext_resource type="PackedScene" uid="uid://bqjj4fvs81gaw" path="res://Scenes/ComponentPanels/quick_texture_entry.tscn" id="2_25k1d"]
 [ext_resource type="PackedScene" uid="uid://ojs61k8nlddj" path="res://Scenes/ComponentPanels/ComponentPreview.tscn" id="3_aum2n"]
 [ext_resource type="Texture2D" uid="uid://cugnc5143oecw" path="res://Textures/UI/pencil.png" id="4_rdyhr"]
@@ -164,9 +164,10 @@ theme_override_constants/margin_bottom = 3
 [node name="Tabs" type="TabContainer" parent="HBoxContainer/VBoxContainer/MarginContainer" unique_id=1800227696]
 unique_name_in_owner = true
 layout_mode = 2
-current_tab = 0
+current_tab = 3
 
 [node name="Single" type="VBoxContainer" parent="HBoxContainer/VBoxContainer/MarginContainer/Tabs" unique_id=147592434]
+visible = false
 layout_mode = 2
 metadata/_tab_index = 0
 
@@ -497,7 +498,6 @@ layout_mode = 2
 icon = ExtResource("1_qeff1")
 
 [node name="Grid" type="VBoxContainer" parent="HBoxContainer/VBoxContainer/MarginContainer/Tabs" unique_id=1464329553]
-visible = false
 layout_mode = 2
 metadata/_tab_index = 3
 

--- a/Scripts/Commands/FlipCommand.cs
+++ b/Scripts/Commands/FlipCommand.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using Godot;
-
 [Command(VisualCommand.Flip)]
 public class FlipCommand : BasicCommand
 {

--- a/Scripts/Commands/ShuffleCommand.cs
+++ b/Scripts/Commands/ShuffleCommand.cs
@@ -1,0 +1,11 @@
+﻿
+    [Command(VisualCommand.Shuffle)]
+    public class ShuffleCommand : BasicCommand
+    {
+        public ShuffleCommand()
+        {
+            Caption = "Shuffle";
+            Command = VisualCommand.Shuffle;
+        }
+    }
+

--- a/Scripts/Commands/ShuffleCommand.cs.uid
+++ b/Scripts/Commands/ShuffleCommand.cs.uid
@@ -1,0 +1,1 @@
+uid://bo2n18v4nby18

--- a/Scripts/ComponentDefinition.cs
+++ b/Scripts/ComponentDefinition.cs
@@ -26,9 +26,15 @@ public partial class ComponentDefinition : Window
 
     public Project CurrentProject { get; set; }
 
+    private AcceptDialog _errorDialog;
+
     // Called when the node enters the scene tree for the first time.
     public override void _Ready()
     {
+        _errorDialog = new AcceptDialog();
+        _errorDialog.Title = "Validation Error";
+        AddChild(_errorDialog);
+
         _createButton = GetNode<Button>("%CreateButton");
         _createButton.Pressed += CreateClicked;
 
@@ -123,6 +129,14 @@ public partial class ComponentDefinition : Window
     {
         if (_panelDictionary[CurName] is ComponentPanelDialogResult r)
         {
+            var errors = r.ValidateParameters(r.GetParams());
+            if (errors != null && errors.Count > 0)
+            {
+                _errorDialog.DialogText = string.Join("\n", errors);
+                _errorDialog.PopupCentered();
+                return;
+            }
+
             CreateObjectEventArgs e = new()
             {
                 ComponentType = r.ComponentType,
@@ -166,6 +180,18 @@ public partial class ComponentDefinition : Window
     {
         if (_mapPrototype == null)
             return;
+
+        if (_panelDictionary[CurName] is ComponentPanelDialogResult r)
+        {
+            var errors = r.ValidateParameters(r.GetParams());
+            if (errors != null && errors.Count > 0)
+            {
+                _errorDialog.DialogText = string.Join("\n", errors);
+                _errorDialog.PopupCentered();
+                return;
+            }
+        }
+
         //update the project prototype
 
         if (

--- a/Scripts/ComponentPanelDialogResult.cs
+++ b/Scripts/ComponentPanelDialogResult.cs
@@ -6,7 +6,6 @@ using Godot;
 
 public abstract partial class ComponentPanelDialogResult : Control
 {
-    public abstract List<string> Validity();
     public abstract Dictionary<string, object> GetParams();
 
     public virtual void Activate() { }
@@ -80,4 +79,6 @@ public abstract partial class ComponentPanelDialogResult : Control
     public virtual void DisplayPrototype(Guid prototypeId) { }
 
     public virtual void DisplayPrototype(Prototype prototype) { }
+
+    public abstract List<string> ValidateParameters(Dictionary<string, object> parameters);
 }

--- a/Scripts/ComponentPanelResults/BagPanelDialogResults.cs
+++ b/Scripts/ComponentPanelResults/BagPanelDialogResults.cs
@@ -54,17 +54,6 @@ public partial class BagPanelDialogResults : ComponentPanelDialogResult
         _preview.ClearComponent();
     }
 
-    public override List<string> Validity()
-    {
-        var ret = new List<string>();
-
-        if (string.IsNullOrEmpty(_nameInput.Text.Trim()))
-        {
-            ret.Add("Component Name required");
-        }
-
-        return ret;
-    }
 
     public override Dictionary<string, object> GetParams()
     {
@@ -127,5 +116,34 @@ public partial class BagPanelDialogResults : ComponentPanelDialogResult
         _showCountButton.ButtonPressed = Utility.GetParam<bool>(prototype.Parameters, "ShowCount");
 
         Activate();
+    }
+
+    public override List<string> ValidateParameters(Dictionary<string, object> parameters)
+    {
+        var ret = new List<string>();
+
+        //must have a name and height. Width/length optional
+        if (parameters.ContainsKey("ComponentName"))
+        {
+            if (string.IsNullOrEmpty(parameters["ComponentName"].ToString()))
+                ret.Add("Name may not be blank");
+        }
+        else
+        {
+            ret.Add("Instance Name not included");
+        }
+
+        var h = Utility.GetParam<float>(parameters, "Height");
+        if (h <= 0)
+            ret.Add("Height must be > 0");
+
+
+        var w = Utility.GetParam<float>(parameters, "Diameter");
+        if (w <= 0)
+            ret.Add("Diameter must be > 0");
+
+
+
+        return ret;
     }
 }

--- a/Scripts/ComponentPanelResults/CubePanelDialogResult.cs
+++ b/Scripts/ComponentPanelResults/CubePanelDialogResult.cs
@@ -54,18 +54,6 @@ public partial class CubePanelDialogResult : ComponentPanelDialogResult
         _preview.ClearComponent();
     }
 
-    public override List<string> Validity()
-    {
-        var ret = new List<string>();
-
-        if (string.IsNullOrEmpty(_nameInput.Text.Trim()))
-        {
-            ret.Add("Component Name required");
-        }
-
-        return ret;
-    }
-
     public override Dictionary<string, object> GetParams()
     {
         var d = new Dictionary<string, object>();
@@ -132,5 +120,38 @@ public partial class CubePanelDialogResult : ComponentPanelDialogResult
             : Colors.Red;
 
         Activate();
+    }
+
+    public override List<string> ValidateParameters(Dictionary<string, object> parameters)
+    {
+        var ret = new List<string>();
+
+        //must have a name and height. Width/length optional
+        if (parameters.ContainsKey("ComponentName"))
+        {
+            if (string.IsNullOrEmpty(parameters["ComponentName"].ToString()))
+                ret.Add("Name may not be blank");
+        }
+        else
+        {
+            ret.Add("Instance Name not included");
+        }
+
+        var h = Utility.GetParam<float>(parameters, "Height");
+        if (h <= 0)
+            ret.Add("Height must be > 0");
+
+
+        var w = Utility.GetParam<float>(parameters, "Width");
+        if (w <= 0)
+            ret.Add("Width must be > 0");
+
+
+        var l = Utility.GetParam<float>(parameters, "Length");
+        if (l <= 0)
+            ret.Add("Length must be > 0");
+
+
+        return ret;
     }
 }

--- a/Scripts/ComponentPanelResults/DiePanelDialogResult.cs
+++ b/Scripts/ComponentPanelResults/DiePanelDialogResult.cs
@@ -267,10 +267,7 @@ public partial class DiePanelDialogResult : ComponentPanelDialogResult
         }
     }
 
-    public override List<string> Validity()
-    {
-        return new List<string>();
-    }
+
 
     public override Dictionary<string, object> GetParams()
     {
@@ -482,5 +479,30 @@ public partial class DiePanelDialogResult : ComponentPanelDialogResult
                 }
             }
         }
+    }
+
+    public override List<string> ValidateParameters(Dictionary<string, object> parameters)
+    {
+        var ret = new List<string>();
+
+        //must have a name and height. Width/length optional
+        if (parameters.ContainsKey("ComponentName"))
+        {
+            if (string.IsNullOrEmpty(parameters["ComponentName"].ToString()))
+                ret.Add("Name may not be blank");
+        }
+        else
+        {
+            ret.Add("Instance Name not included");
+        }
+
+
+        var w = Utility.GetParam<float>(parameters, "Diameter");
+        if (w <= 0)
+            ret.Add("Diameter must be > 0");
+
+
+
+        return ret;
     }
 }

--- a/Scripts/ComponentPanelResults/DiscPanelDialogResult.cs
+++ b/Scripts/ComponentPanelResults/DiscPanelDialogResult.cs
@@ -49,17 +49,7 @@ public partial class DiscPanelDialogResult : ComponentPanelDialogResult
         _preview.ClearComponent();
     }
 
-    public override List<string> Validity()
-    {
-        var ret = new List<string>();
 
-        if (string.IsNullOrEmpty(_nameInput.Text.Trim()))
-        {
-            ret.Add("Component Name required");
-        }
-
-        return ret;
-    }
 
     public override Dictionary<string, object> GetParams()
     {
@@ -119,5 +109,34 @@ public partial class DiscPanelDialogResult : ComponentPanelDialogResult
             : Colors.Red;
 
         Activate();
+    }
+
+    public override List<string> ValidateParameters(Dictionary<string, object> parameters)
+    {
+        var ret = new List<string>();
+
+        //must have a name and height. Width/length optional
+        if (parameters.ContainsKey("ComponentName"))
+        {
+            if (string.IsNullOrEmpty(parameters["ComponentName"].ToString()))
+                ret.Add("Name may not be blank");
+        }
+        else
+        {
+            ret.Add("Instance Name not included");
+        }
+
+        var h = Utility.GetParam<float>(parameters, "Height");
+        if (h <= 0)
+            ret.Add("Height must be > 0");
+
+
+        var w = Utility.GetParam<float>(parameters, "Diameter");
+        if (w <= 0)
+            ret.Add("Diameter must be > 0");
+
+
+
+        return ret;
     }
 }

--- a/Scripts/ComponentPanelResults/MeeplePanel.cs
+++ b/Scripts/ComponentPanelResults/MeeplePanel.cs
@@ -356,11 +356,6 @@ public partial class MeeplePanel : ComponentPanelDialogResult
 
     #endregion
 
-    public override List<string> Validity()
-    {
-        return new List<string>();
-    }
-
     public override Dictionary<string, object> GetParams()
     {
         var d = new Dictionary<string, object>();
@@ -430,5 +425,52 @@ public partial class MeeplePanel : ComponentPanelDialogResult
         }
 
         Activate();
+    }
+
+    public override List<string> ValidateParameters(Dictionary<string, object> parameters)
+    {
+        var ret = new List<string>();
+
+        //must have a name and height. Width/length optional
+        if (parameters.ContainsKey("ComponentName"))
+        {
+            if (string.IsNullOrEmpty(parameters["ComponentName"].ToString()))
+                ret.Add("Name may not be blank");
+        }
+        else
+        {
+            ret.Add("Instance Name not included");
+        }
+
+        var h = Utility.GetParam<float>(parameters, "Height");
+        if (h <= 0)
+            ret.Add("Height must be > 0");
+
+
+        var w = Utility.GetParam<float>(parameters, "Thickness");
+        if (w <= 0)
+            ret.Add("Thickness must be > 0");
+
+        //check grid
+        bool found = false;
+        foreach(var i in _gridState)
+        {
+            foreach(var j in i)
+            {
+                if (j)
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (found) break;
+        }
+
+        if (!found)
+        {
+            ret.Add("Grid must have at least one active cell");
+        }
+
+        return ret;
     }
 }

--- a/Scripts/ComponentPanelResults/PrintedPanelDialogResult.cs
+++ b/Scripts/ComponentPanelResults/PrintedPanelDialogResult.cs
@@ -606,13 +606,6 @@ public partial class PrintedPanelDialogResult : ComponentPanelDialogResult
             }
         );
 
-    public override List<string> Validity()
-    {
-        var ret = new List<string>();
-        if (string.IsNullOrEmpty(_nameInput.Text.Trim()))
-            ret.Add("Component Name required");
-        return ret;
-    }
 
     public override Dictionary<string, object> GetParams()
     {
@@ -974,5 +967,33 @@ public partial class PrintedPanelDialogResult : ComponentPanelDialogResult
 
         UpdateDimensionUI();
         Activate();
+    }
+
+    public override List<string> ValidateParameters(Dictionary<string, object> parameters)
+    {
+        var ret = new List<string>();
+
+        //must have a name and height. Width/length optional
+        if (parameters.ContainsKey("ComponentName"))
+        {
+            if (string.IsNullOrEmpty(parameters["ComponentName"].ToString()))
+                ret.Add("Name may not be blank");
+        }
+        else
+        {
+            ret.Add("Instance Name not included");
+        }
+
+        var h = Utility.GetParam<float>(parameters, "Height");
+        if (h <= 0)
+            ret.Add("Height must be > 0");
+
+
+        var w = Utility.GetParam<float>(parameters, "Width");
+        if (w <= 0)
+            ret.Add("Width must be > 0");
+
+
+        return ret;
     }
 }

--- a/Scripts/ComponentPanelResults/TrayPanelDialogResult.cs
+++ b/Scripts/ComponentPanelResults/TrayPanelDialogResult.cs
@@ -33,9 +33,28 @@ public partial class TrayPanelDialogResult : ComponentPanelDialogResult
         LoadPrototypeList();
         _prototypeList.ItemSelected += PrototypeSelected;
 
+        UpdatePrototypeSelection();
+
         _preview = GetNode<ComponentPreview>("%Preview");
     }
 
+    private void UpdatePrototypeSelection()
+    {
+        if (_prototypeList == null) return;
+        
+        if (!string.IsNullOrEmpty(_selectedPrototypeKey))
+        {
+            for (int i = 0; i < _prototypeList.GetItemCount(); i++)
+            {
+                if (_prototypeList.GetItemMetadata(i).ToString() == _selectedPrototypeKey)
+                {
+                    _prototypeList.Selected = i;
+                    break;
+                }
+            }
+        }
+    }
+    
     private void LoadPrototypeList()
     {
         _prototypeList.Clear();
@@ -82,17 +101,6 @@ public partial class TrayPanelDialogResult : ComponentPanelDialogResult
         _preview.ClearComponent();
     }
 
-    public override List<string> Validity()
-    {
-        var ret = new List<string>();
-
-        if (string.IsNullOrEmpty(_nameInput.Text.Trim()))
-        {
-            ret.Add("Component Name required");
-        }
-
-        return ret;
-    }
 
     public override Dictionary<string, object> GetParams()
     {
@@ -159,6 +167,48 @@ public partial class TrayPanelDialogResult : ComponentPanelDialogResult
             ? (Color)prototype.Parameters["Color"]
             : Colors.Red;
 
+        _selectedPrototypeKey = prototype.Parameters.ContainsKey("Prototype")
+            ? prototype.Parameters["Prototype"].ToString()
+            : string.Empty;
+        
+        UpdatePrototypeSelection();
+        
         Activate();
+    }
+
+    public override List<string> ValidateParameters(Dictionary<string, object> parameters)
+    {
+        var ret = new List<string>();
+
+        //must have a name and height. Width/length optional
+        if (parameters.ContainsKey("ComponentName"))
+        {
+            if (string.IsNullOrEmpty(parameters["ComponentName"].ToString()))
+                ret.Add("Name may not be blank");
+        }
+        else
+        {
+            ret.Add("Instance Name not included");
+        }
+
+        var h = Utility.GetParam<float>(parameters, "Height");
+        if (h <= 0)
+            ret.Add("Height must be > 0");
+
+
+        var w = Utility.GetParam<float>(parameters, "Width");
+        if (w <= 0)
+            ret.Add("Width must be > 0");
+
+
+        var l = Utility.GetParam<float>(parameters, "Length");
+        if (l <= 0)
+            ret.Add("Length must be > 0");
+
+        var p = Utility.GetParam<string>(parameters, "Prototype");
+        if (string.IsNullOrEmpty(p))
+            ret.Add("Component must be specified");
+
+        return ret;
     }
 }

--- a/Scripts/JsonUtilities.cs
+++ b/Scripts/JsonUtilities.cs
@@ -175,6 +175,7 @@ public static class JsonUtilities
                 p.Add("GridCols", TryGetInt(d, "GridCols"));
                 p.Add("GridCount", TryGetInt(d, "GridCount"));
                 p.Add("DifferentBack", TryGetBool(d, "DifferentBack"));
+                p.Add("GridSingleBack", TryGetBool(d, "GridSingleBack"));
                 break;
 
             case VcToken.TokenBuildMode.Template:

--- a/primary_scene.tscn
+++ b/primary_scene.tscn
@@ -160,12 +160,12 @@ item_6/id = 4
 
 [node name="ComponentName" type="Label" parent="UI" unique_id=843150342]
 unique_name_in_owner = true
-anchors_preset = 1
-anchor_left = 1.0
-anchor_right = 1.0
-offset_left = -40.0
-offset_bottom = 23.0
-grow_horizontal = 0
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -23.0
+offset_right = 40.0
+grow_vertical = 0
 horizontal_alignment = 2
 
 [node name="TextureFactory" type="SubViewport" parent="UI" unique_id=1184539869]


### PR DESCRIPTION
Added initial validation for component creation panels Moved the component name to a better spot on the game panel (lower left)
Fixed issue with saving/restoring the the 'single grid image' setting for printed material